### PR TITLE
Maintain QueuePos for history

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   webpush
-
-BUNDLED WITH
-   1.17.3

--- a/app/controllers/stations_controller.rb
+++ b/app/controllers/stations_controller.rb
@@ -4,7 +4,7 @@ class StationsController < ApplicationController
 
     include SongsHelper
 
-    before_action :set_station, only: [:show]
+    before_action :set_station, only: [:show, :change_queue_pos, :edit_queue_pos]
 
     # GET /stations
     def index
@@ -29,6 +29,39 @@ class StationsController < ApplicationController
 
     # GET /stations/1
     def show
+    end
+
+    def change_queue_pos
+    end
+
+    # POST /stations/1/edit_queue_pos
+    def edit_queue_pos
+        # print "$$$$$$$$$ Arrived Here $$$$$\n"
+        # print "$$$$$$$$$ Arrived Here $$$$$\n"
+        # print "$$$$$$$$$ Arrived Here $$$$$\n"
+        # print "  InParam: %s\n" % params[:new_queue_pos]
+
+
+        if not logged_in?
+            return json_error "must log in to add to the queue"
+        end
+        station = current_user.station
+
+        # print "  CurQueuePos: %s\n" % station.queue_pos
+
+        in_param = Integer(params[:new_queue_pos])
+
+        if in_param <= station.queue_max and in_param >= 0
+            station.update queue_pos: in_param
+        end
+
+        # print "  QueuePos: %s\n" % station.queue_pos
+
+
+        redirect_to "/stations/1"
+
+        # json_ok
+
     end
 
     # PUT /stations/1

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -7,6 +7,10 @@ class Station < ActiveRecord::Base
         QueueEntry.where(station: self).where.not(position: nil).order(:position)
     end
 
+    def queue_pos
+        return self.now_playing.position
+    end
+
     def queue_song(song, selector)
         if song.source != "Spotify"
             return "Please select a song from Spotify (not #{song.source})"

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -71,34 +71,39 @@ class Station < ActiveRecord::Base
         # Whatever happens, this method will ensure that `song` is now playing.
 
         entry = nil
-        while queue.any?
 
+        tmp_pos = queue_pos
 
-            print "$$$$$$$$$$$$$$$$$$$$$$$44444\n"
-            print "$$$$$$$$$$$$$$$$$$$$$$$44444\n"
-            print "$$$$$$$$$$$$$$$$$$$$$$$44444\n"
-            print "  QueueSize: %d\n" % queue.length
-            print "  QueuePos: %d\n" % queue_pos
-            print "  QueueMax: %d\n" % queue_max
-            print "  QueueSong: %s\n" % queue[0].song.name
-            print "  SongIn: %s\n" % song.name 
+        while queue.any? and tmp_pos <= queue_max
 
-            if queue[0].song == song then
-                entry = queue[0]
+            # print "$$$$$$$$$$$$$$$$$$$$$$$44444\n"
+            # print "$$$$$$$$$$$$$$$$$$$$$$$44444\n"
+            # print "$$$$$$$$$$$$$$$$$$$$$$$44444\n"
+            # print "  QueueSize: %d\n" % queue.length
+            # print "  QueuePos: %d\n" % queue_pos
+            # print "  TmpPos: %d\n" % tmp_pos
+            # print "  QueueMax: %d\n" % queue_max
 
-                print "Found song pos: %d\n" % entry.position
+            if queue[tmp_pos - queue_pos].song == song then
+                entry = queue[tmp_pos - queue_pos]
+
+                # print "Found song pos: %d\n" % entry.position
+
+                update queue_pos: tmp_pos # Update actual queue pos if found the song
+                queue.reload
             else
-                update queue_pos: queue_pos+1
+                tmp_pos = tmp_pos + 1
             end
 
 
             # queue[0].update position: nil+
-            queue.reload
 
             break unless entry.nil?
         end
 
         if entry.nil? then
+            # print "$$$$$$$$$$$$$$$$$$$$$$$44444\n"
+            # print "  Song not found. Creating new QueueEntry\n"
             entry = QueueEntry.create song: song
         end
 

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -4,11 +4,24 @@ class Station < ActiveRecord::Base
     has_many :users
 
     def queue
+        self.queue_pos
         QueueEntry.where(station: self).where.not(position: nil).order(:position)
     end
 
     def queue_pos
-        return self.now_playing.position
+        puts "$$$$$$$$$$$$$$$$$$$"
+        puts "$$$$$$$$$$$$$$$$$$$"
+
+        if self.now_playing.position # If now playing was added by us, use that as the index
+            result =  self.now_playing.position || 0
+            puts "  In NowPlaying"
+        else # Is now_playing was added externally (drift), just return max queue pos
+            result = QueueEntry.where(station: self).where.not(position: nil).maximum(:position) || 0
+        end
+
+        print "  QueuePos: %d\n" % result
+        print "  QueueMax: %d\n" % QueueEntry.where(station: self).where.not(position: nil).maximum(:position)
+
     end
 
     def queue_song(song, selector)
@@ -67,7 +80,7 @@ class Station < ActiveRecord::Base
                 entry = queue[0]
             end
 
-            queue[0].update position: nil
+            # queue[0].update position: nil
             queue.reload
 
             break unless entry.nil?

--- a/app/views/stations/change_queue_pos.html.erb
+++ b/app/views/stations/change_queue_pos.html.erb
@@ -1,0 +1,10 @@
+<p id="notice"><%= notice %></p>
+
+<form action="/stations/1/edit_queue_pos" method="post">
+    <label for="new_queue_pos">Change queue_pos?</label><br>
+    <input type='text' id='new_queue_pos' name="new_queue_pos" value=<%= @station.queue_pos %> ><br>
+    <!-- <input type='text' id='new_queue_pos' name="new_queue_pos" value=0 ><br> -->
+    <input type="submit" name="Submit">
+
+</form>
+

--- a/app/views/stations/show.html.erb
+++ b/app/views/stations/show.html.erb
@@ -20,16 +20,18 @@
       <th>Album</th>
       <th>Selector</th>
     </tr>
-  <% @station.queue.each_with_index do |queue_entry, i| %>
-    <% if i > @station.queue.length - 20 %>
-      <tr>
-        <td><%= i + 1 %></td>
-        <td><%= queue_entry.song.title %></td>
-        <td><%= queue_entry.song.artist %></td>
-        <td><%= queue_entry.song.album %></td>
-        <td><%= queue_entry.selector.username %></td>
-      </tr>
-    <% end %>
+  <% @station.queue_before(5).each_with_index do |queue_entry, i| %>
+    <tr>
+      <!-- <td><%= i + 1 %></td> -->
+      <td><%= queue_entry.position - @station.queue_pos%></td>
+      <td><%= queue_entry.song.title %></td>
+      <td><%= queue_entry.song.artist %></td>
+      <td><%= queue_entry.song.album %></td>
+      <td><%= queue_entry.selector.username %></td>
+      <td><%= queue_entry.position%></td>
+      <td><%= @station.queue_max%></td>
+      <td><%= @station.queue_pos%></td>
+    </tr>
   <% end %>
 </table>
 

--- a/app/views/stations/show.html.erb
+++ b/app/views/stations/show.html.erb
@@ -14,11 +14,12 @@
 <!-- Song queue -->
 <table>
     <tr>
-      <th></th>
+      <th>i</th>
       <th>Song</th>
       <th>Artist</th>
       <th>Album</th>
       <th>Selector</th>
+      <th>QPos</th>
     </tr>
   <% @station.queue_before(5).each_with_index do |queue_entry, i| %>
     <tr>
@@ -29,8 +30,6 @@
       <td><%= queue_entry.song.album %></td>
       <td><%= queue_entry.selector.username %></td>
       <td><%= queue_entry.position%></td>
-      <td><%= @station.queue_max%></td>
-      <td><%= @station.queue_pos%></td>
     </tr>
   <% end %>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
 
   get 'sessions/test_webrtc'
 
+  get '/stations/:id/change_queue_pos', to: "stations#change_queue_pos"
+  post '/stations/:id/edit_queue_pos',  to: "stations#edit_queue_pos"
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/migrate/20200823202957_add_queue_pos_to_stations.rb
+++ b/db/migrate/20200823202957_add_queue_pos_to_stations.rb
@@ -1,0 +1,5 @@
+class AddQueuePosToStations < ActiveRecord::Migration
+  def change
+    add_column :stations, :queue_pos, :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20200830005529) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.integer  "now_playing_id"
+    t.integer  "queue_pos"
   end
 
   add_index "stations", ["now_playing_id"], name: "index_stations_on_now_playing_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ end
 
 def spotify_station(station, songs=[])
 
-    station = Station.create name: station
+    station = Station.create name: station, queue_pos: 0
     songs.each_with_index do |song, i|
         user = User.create username: "User#{i}"
         SongsStations.create station: station, song: spotify_song(song), position: i, selector: user


### PR DESCRIPTION
all queue_entries retain their number/position in the queue. A resource variable "queue_pos" tracks the position in the queue, which is separate from the now_playing. I also added a page to edit the queue_pos in case it fails